### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       release-tag: v${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Extract latest section from CHANGELOG.md
         id: parse-changelog


### PR DESCRIPTION
## Summary
update actions/checkout to v4 to use node 20 runtime

v4 release notes: https://github.com/actions/checkout/releases/tag/v4.0.0